### PR TITLE
Revert "CSS instructions for formatting in the notification.tpl"

### DIFF
--- a/view/templates/notifications/notification.tpl
+++ b/view/templates/notifications/notification.tpl
@@ -1,29 +1,4 @@
 
-<style>
-	/* Flexbox layout to align the icon and text in a single line */
-	.notif-item a {
-		display: flex;
-		align-items: flex-start; /* Aligns items at the start of the flex container */
-	}
-
-	/* Margin to create space between the icon and the text */
-	.notif-image {
-		margin-right: 10px; /* Adjust the space between the icon and text as needed */
-
-		}
-
-	/* Styles to ensure the text wraps properly after 70 characters */
-	.notif-text {
-		display: inline-block; /* Allows the text to be constrained within a block-level element */
-		max-width: 70ch; /* Limits the maximum width of the text to 70 characters */
-		overflow-wrap: break-word; /* Ensures that words will break if necessary to fit the width */
-	}
-</style>
-
 <div class="notif-item {{if !$item_seen}}unseen{{/if}}" {{if $item_seen}}aria-hidden="true"{{/if}}>
-	<a href="{{$notification.link}}">
-		<img src="{{$notification.image}}" aria-hidden="true" class="notif-image">
-		<span class="notif-text">{{$notification.text}}</span>
-		<span class="notif-when">{{$notification.ago}}</span>
-	</a>
+	<a href="{{$notification.link}}"><img src="{{$notification.image}}" aria-hidden="true" class="notif-image">{{$notification.text}} <span class="notif-when">{{$notification.ago}}</span></a>
 </div>


### PR DESCRIPTION
A space has been inserted between the user icon and the outlined text. Texts are wrapped after 70 characters.

Today:

![2024-08-07_12-17](https://github.com/user-attachments/assets/4e728982-6a8e-4c56-be9c-753540ef5898)


Future:

![2024-08-07_12-17_1](https://github.com/user-attachments/assets/98cb560e-069a-4fbc-9d2f-2ba21c7d6e8b)
